### PR TITLE
Fix mount path

### DIFF
--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -41,6 +41,9 @@ class DockerService(resource.Resource):
             data=json.dumps(data),
         )
 
+    def _fork(self, *args, **kw):
+        return utils.fork(*args, **kw)
+
     @defer.inlineCallbacks
     def _mount_fs(self, server, volume, dst):
         """ Mount a gluster filesystem on this host
@@ -53,7 +56,7 @@ class DockerService(resource.Resource):
             if e.errno != 17:
                 raise e
 
-        out, err, code = yield utils.fork('/bin/mount', args=(
+        out, err, code = yield self._fork('/bin/mount', args=(
             '-t', 'glusterfs', '%s:/%s' % (server, volume), dst))
 
         if code > 0:
@@ -67,9 +70,10 @@ class DockerService(resource.Resource):
         """ Mount a gluster filesystem on this host
         """
 
-        out, err, code = yield utils.fork('/bin/umount', args=(path,))
+        out, err, code = yield self._fork('/bin/umount', args=(path,))
 
         if code > 0:
+            # TODO fix this
             if "%s is not mounted" % path in err:
                 defer.returnValue(True)
             else:

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -73,8 +73,9 @@ class DockerService(resource.Resource):
         out, err, code = yield self._fork('/bin/umount', args=(path,))
 
         if code > 0:
-            # TODO fix this
-            if "%s is not mounted" % path in err:
+
+            if (path in err) and ("not mounted" in err):
+                # if volume not mounted
                 defer.returnValue(True)
             else:
                 raise Exception(err)

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -109,30 +109,26 @@ class DockerService(resource.Resource):
     @defer.inlineCallbacks
     def unmount_volume(self, request, data):
         name = data['Name']
-        path = os.path.join(self.mount_path, name)
-
         try:
-            if (yield self._umount_fs(path)):
-                defer.returnValue({"Err": None})
-            else:
-                # Try older mount paths
-                paths = self.get_paths(name)
-                for path in paths:
-                    yield self._umount_fs(path)
+            # Unmount from all paths
+            paths = self.get_paths(name)
+            for path in paths:
+                yield self._umount_fs(path)
 
-                defer.returnValue({"Err": None})
+            defer.returnValue({"Err": None})
 
         except Exception, e:
             defer.returnValue({"Err": repr(e)})
 
     def get_paths(self, name):
         """
-        Function to return an array of old mount paths
+        Function to return an array of mount paths
         :param name: Name of volume
         :return: list of possible paths for given volume name
         """
-
-        return [os.path.join(path, name) for path in self.old_paths]
+        paths = [os.path.join(path, name) for path in self.old_paths]
+        paths.append(os.path.join(self.mount_path, name))
+        return paths
 
     def get_volume_path(self, request, data):
         name = data['Name']

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -32,10 +32,7 @@ class DockerService(resource.Resource):
             'mount_path',
             '/var/lib/docker-xylem/volumes'
         )
-        self.old_paths = {
-            '/var/lib/docker/volumes',
-            'var/lib/docker-xylem',
-        }
+        self.old_paths = config.get('old_mount_paths', [])
         self.current = {}
 
     def xylem_request(self, queue, call, data):

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -116,12 +116,25 @@ class DockerService(resource.Resource):
                 defer.returnValue({"Err": None})
             else:
                 # Try older mount paths
-                paths = os.path.join(self.old_paths, name)
+                paths = self.get_paths(name)
                 for path in paths:
                     yield self._umount_fs(path)
 
+                defer.returnValue({"Err": None})
+
         except Exception, e:
             defer.returnValue({"Err": repr(e)})
+
+    def get_paths(self, name):
+        """
+        Function to return an array of old mount paths
+        :param name: Name of volume
+        :return: list of possible paths for given volume name
+        """
+        paths = []
+        for path in self.old_paths:
+            paths.append(os.path.join(path, name))
+        return paths
 
     def get_volume_path(self, request, data):
         name = data['Name']

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -28,10 +28,13 @@ class DockerService(resource.Resource):
 
         self.xylem_host = config['host']
         self.xylem_port = config.get('port', 7701)
-        self.mount_path = config.get('mount_path', '/var/lib/docker-xylem/volumes')
+        self.mount_path = config.get(
+            'mount_path',
+            '/var/lib/docker-xylem/volumes'
+        )
         self.old_paths = {
             '/var/lib/docker/volumes',
-            'var/lib/docker-xylem/'
+            'var/lib/docker-xylem/',
         }
         self.current = {}
 

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -34,7 +34,7 @@ class DockerService(resource.Resource):
         )
         self.old_paths = {
             '/var/lib/docker/volumes',
-            'var/lib/docker-xylem/',
+            'var/lib/docker-xylem',
         }
         self.current = {}
 

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -134,10 +134,8 @@ class DockerService(resource.Resource):
         :param name: Name of volume
         :return: list of possible paths for given volume name
         """
-        paths = []
-        for path in self.old_paths:
-            paths.append(os.path.join(path, name))
-        return paths
+
+        return [os.path.join(path, name) for path in self.old_paths]
 
     def get_volume_path(self, request, data):
         name = data['Name']

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
     def setUp(self):
         self.service = DockerService({
             'host': 'localhost',
-            'mount_path': '/mnt'
+            'mount_path': '/tmp/docker-xylem-test'
         })
 
         self.service.xylem_request = lambda *a: defer.maybeDeferred(
@@ -73,7 +73,10 @@ class Test(unittest.TestCase):
         result = yield self.service._route_request(FakeRequest(
             '/VolumeDriver.Mount', {'Name': 'testvol', 'Opts': {}}))
 
-        self.assertEquals(result['Mountpoint'], '/mnt/testvol')
+        self.assertEquals(
+            result['Mountpoint'],
+            '/tmp/docker-xylem-test/testvol'
+        )
         self.assertEquals(result['Err'], None)
 
         result = yield self.service._route_request(FakeRequest(
@@ -86,7 +89,10 @@ class Test(unittest.TestCase):
         result = yield self.service._route_request(FakeRequest(
             '/VolumeDriver.Path', {'Name': 'testvol'}))
 
-        self.assertEquals(result['Mountpoint'], '/mnt/testvol')
+        self.assertEquals(
+            result['Mountpoint'],
+            '/tmp/docker-xylem-test/testvol'
+        )
 
     @defer.inlineCallbacks
     def test_get(self):

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -18,7 +18,8 @@ class Test(unittest.TestCase):
     def setUp(self):
         self.service = DockerService({
             'host': 'localhost',
-            'mount_path': '/tmp/docker-xylem-test'
+            'mount_path': '/tmp/docker-xylem-test',
+            'old_mount_paths:': ['/some/old/path', '/another/random/old/path', '/just/one/more/wont/hurt']
         })
 
         self.service.xylem_request = lambda *a: defer.maybeDeferred(

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -19,7 +19,10 @@ class Test(unittest.TestCase):
         self.service = DockerService({
             'host': 'localhost',
             'mount_path': '/tmp/docker-xylem-test',
-            'old_mount_paths:': ['/some/old/path', '/another/random/old/path', '/just/one/more/wont/hurt']
+            'old_mount_paths:': [
+                '/some/old/path', '/another/random/old/path',
+                '/just/one/more/wont/hurt'
+            ]
         })
 
         self.service.xylem_request = lambda *a: defer.maybeDeferred(
@@ -144,7 +147,6 @@ class Test(unittest.TestCase):
 
         self.assertEquals(result1, True)
         self.assertEquals(result2['Err'], None)
-
 
     @defer.inlineCallbacks
     def test_unmount_changed_path(self):

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -19,7 +19,7 @@ class Test(unittest.TestCase):
         self.service = DockerService({
             'host': 'localhost',
             'mount_path': '/tmp/docker-xylem-test',
-            'old_mount_paths:': [
+            'old_mount_paths': [
                 '/some/old/path', '/another/random/old/path',
                 '/just/one/more/wont/hurt'
             ]
@@ -136,6 +136,9 @@ class Test(unittest.TestCase):
         """
         Test for /Volume.Unmount when the mount path has NOT been changed
         """
+        # Check if old mount paths were read correctly
+        self.assertFalse(len(self.service.old_paths) == 0)
+
         data = {'Name': 'testvol', 'ID': 'RANDOM_ID'}
         yield self.service._route_request(FakeRequest(
             '/VolumeDriver.Mount', data))
@@ -153,6 +156,9 @@ class Test(unittest.TestCase):
         """
         Test for /Volume.Unmount when the mount path HAS BEEN changed
         """
+
+        # Check if old mount paths were read correctly
+        self.assertFalse(len(self.service.old_paths)==0)
 
         data = {'Name': 'testvol', 'ID': 'RANDOM_ID'}
         yield self.service._route_request(FakeRequest(

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -158,7 +158,7 @@ class Test(unittest.TestCase):
         """
 
         # Check if old mount paths were read correctly
-        self.assertFalse(len(self.service.old_paths)==0)
+        self.assertFalse(len(self.service.old_paths) == 0)
 
         data = {'Name': 'testvol', 'ID': 'RANDOM_ID'}
         yield self.service._route_request(FakeRequest(

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -24,14 +24,13 @@ class Test(unittest.TestCase):
         self.service.xylem_request = lambda *a: defer.maybeDeferred(
             self.xylem_request, *a)
 
-        self.service._mount_fs = lambda *a: defer.maybeDeferred(
-            self.mountfs, *a)
+        self.service._fork = self.fork
 
-        self.service._umount_fs = lambda *a: defer.maybeDeferred(
-            self.mountfs, *a)
-
-    def mountfs(self, *a):
-        pass
+    def fork(self, *args, **kw):
+        """
+        Method to replace service._fork for testing purposes
+        """
+        return defer.succeed(("", "", 0))
 
     def xylem_request(self, queue, call, data):
         if call == 'createvolume':

--- a/docker_xylem/tests/test_docker_xylem.py
+++ b/docker_xylem/tests/test_docker_xylem.py
@@ -129,13 +129,10 @@ class Test(unittest.TestCase):
         self.assertEquals(result['Capabilities']['Scope'], 'global')
 
     @defer.inlineCallbacks
-    def test_unmount(self):
+    def test_unmount_unchanged_path(self):
         """
-        Test for /Volume.Unmount
+        Test for /Volume.Unmount when the mount path has NOT been changed
         """
-
-        # Try unmounting with unchanged mount path.
-
         data = {'Name': 'testvol', 'ID': 'RANDOM_ID'}
         yield self.service._route_request(FakeRequest(
             '/VolumeDriver.Mount', data))
@@ -148,22 +145,28 @@ class Test(unittest.TestCase):
         self.assertEquals(result1, True)
         self.assertEquals(result2['Err'], None)
 
-        # Try unmount with a changed mount path
 
+    @defer.inlineCallbacks
+    def test_unmount_changed_path(self):
+        """
+        Test for /Volume.Unmount when the mount path HAS BEEN changed
+        """
+
+        data = {'Name': 'testvol', 'ID': 'RANDOM_ID'}
         yield self.service._route_request(FakeRequest(
             '/VolumeDriver.Mount', data))
         self.service.mount_path = '/var/lib/docker/volumes'
         path = self.service.get_volume_path(None, data)['Mountpoint']
 
-        # Replace the fork function to create a mount error
+        # Replace the fork function to create an unmount error
         self.service._fork = self.fork_unmount_err
 
-        result3 = yield self.service._umount_fs(path)
-        result4 = yield self.service._route_request(FakeRequest(
+        result1 = yield self.service._umount_fs(path)
+        result2 = yield self.service._route_request(FakeRequest(
             '/VolumeDriver.Unmount', data))
 
-        self.assertEquals(result3, False)
-        self.assertEquals(result4['Err'], None)
+        self.assertEquals(result1, False)
+        self.assertEquals(result2['Err'], None)
 
-        # Restore the old test fork function
+        # Restore the old test fork function?
         self.service._fork = self.fork

--- a/xylem-plugin.yml
+++ b/xylem-plugin.yml
@@ -1,4 +1,6 @@
 host: my-xylem-server
 port: 7701
 mount_path: /var/lib/docker-xylem/volumes
+old_mount_paths:
+  - /var/lib/docker/volumes
 socket: /run/docker/plugins/xylem.sock

--- a/xylem-plugin.yml
+++ b/xylem-plugin.yml
@@ -1,4 +1,4 @@
 host: my-xylem-server
 port: 7701
-mount_path: /var/lib/docker/volumes
+mount_path: /var/lib/docker-xylem/volumes
 socket: /run/docker/plugins/xylem.sock


### PR DESCRIPTION
Added code to account for the change in mount path. If an unmount fails, docker-xylem will attempt to unmount using old mount paths.