### PR TITLE
Support Twisted 13.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
 language: python
 python:
   - 2.7
+matrix:
+  include:
+    # Python 2.7 with the latest Twisted.
+    - python: 2.7
+    # Python 2.7 with Twisted 13.2.0 for Ubuntu.
+    - python: 2.7
+      env: TWISTED_VERSION=13.2.0
+
 install:
-    - pip install .
-    - pip install flake8
+  - pip install -U pip
+  - if [ ! -z "$TWISTED_VERSION" ]; then pip install $TWISTED_VERSION; fi
+  - pip install .
+  - pip install flake8
 services:
-    - redis-server
+  - redis-server
 script:
-    - trial docker_xylem
-    - flake8
+  - trial docker_xylem
+  - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ python:
   - 2.7
 matrix:
   include:
-    # Python 2.7 with the latest Twisted.
-    - python: 2.7
-    # Python 2.7 with Twisted 13.2.0 for Ubuntu.
+    # Also build with Twisted 13.2.0 for Ubuntu.
     - python: 2.7
       env: TWISTED_VERSION=13.2.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 install:
   - pip install -U pip
-  - if [ ! -z "$TWISTED_VERSION" ]; then pip install $TWISTED_VERSION; fi
+  - if [ ! -z "$TWISTED_VERSION" ]; then pip install "Twisted==$TWISTED_VERSION"; fi
   - pip install .
   - pip install flake8
 services:

--- a/docker_xylem/compat.py
+++ b/docker_xylem/compat.py
@@ -1,0 +1,18 @@
+"""
+Very limited reimplementation of some of `twisted.logger.Logger`'s public
+API so we can use older Twisted versions that don't have the new logging
+features.
+"""
+
+try:
+    from twisted.logger import Logger
+except ImportError:
+    import logging
+    from twisted.python import log
+
+    class Logger(object):
+        def info(self, format, **kw):
+            log.msg(format.format(**kw), logLevel=logging.INFO)
+
+        def warn(self, format, **kw):
+            log.msg(format.format(**kw), logLevel=logging.WARNING)

--- a/docker_xylem/service.py
+++ b/docker_xylem/service.py
@@ -4,9 +4,9 @@ import cgi
 
 from twisted.internet import defer
 from twisted.web import server, resource
-from twisted.logger import Logger
 
 from docker_xylem import utils
+from docker_xylem.compat import Logger
 
 
 class DockerService(resource.Resource):

--- a/docker_xylem/utils.py
+++ b/docker_xylem/utils.py
@@ -8,9 +8,9 @@ from twisted.internet import reactor, protocol, defer, error
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 from twisted.web.client import Agent
-from twisted.logger import Logger
-
 from twisted.internet.endpoints import clientFromString
+
+from docker_xylem.compat import Logger
 
 
 class SocketyAgent(Agent):


### PR DESCRIPTION
We build a .deb package that depends on `python-twisted` which, in Ubuntu 14.04, is Twisted 13.2.0.